### PR TITLE
Allow case-insensitive SVG attributes

### DIFF
--- a/packages/svg-baker/lib/transformations/svg-to-symbol.js
+++ b/packages/svg-baker/lib/transformations/svg-to-symbol.js
@@ -27,7 +27,7 @@ function svgToSymbol(config = null) {
     root.attrs = root.attrs || {};
 
     const attrNames = Object.keys(root.attrs);
-    const attrNamesToPreserve = micromatch(attrNames, cfg.preserve);
+    const attrNamesToPreserve = micromatch(attrNames, cfg.preserve, { nocase: true });
 
     attrNames.forEach((name) => {
       if (!attrNamesToPreserve.includes(name)) {


### PR DESCRIPTION
Allow SVG attributes in lowercase etc.

viewBox or viewbox for example:
`<svg viewbox="0 0 24 24">...</svg>`